### PR TITLE
Improve SEO by updating URLs and metadata

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,15 +13,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: "Web Development Hub: Your Ultimate Guide to Resources, Tools, and Communities",
     description: "Explore a comprehensive collection of web development resources, including tutorials, tools, frameworks, libraries, communities, and blogs. Elevate your skills and build amazing web experiences.",
-    url: "https://yourwebsiteurl.com",
-    images: [
-      {
-        url: "/og-image.png",
-        width: 1200,
-        height: 630,
-        alt: "Web Development Hub - Your guide to dev resources",
-      },
-    ],
+    url: "https://webdevhub.link/",
     locale: "en_US",
     type: "website",
   },
@@ -29,8 +21,6 @@ export const metadata: Metadata = {
     card: "summary_large_image",
     title: "Web Development Hub: Your Ultimate Guide to Resources, Tools, and Communities",
     description: "Explore a comprehensive collection of web development resources, including tutorials, tools, frameworks, libraries, communities, and blogs. Elevate your skills and build amazing web experiences.",
-    images: ["/twitter-image.png"],
-    creator: "@yourtwitterhandle",
   },
 };
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://yourwebsiteurl.com/sitemap.xml
+Sitemap: https://webdevhub.link/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,37 +1,37 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://yourwebsiteurl.com/</loc>
+    <loc>https://webdevhub.link/</loc>
     <lastmod>2023-10-27</lastmod> <!-- Placeholder date, can be updated -->
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://yourwebsiteurl.com/learning-resources</loc>
+    <loc>https://webdevhub.link/learning-resources</loc>
     <lastmod>2023-10-27</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://yourwebsiteurl.com/developer-tools</loc>
+    <loc>https://webdevhub.link/developer-tools</loc>
     <lastmod>2023-10-27</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://yourwebsiteurl.com/frameworks-and-libraries</loc>
+    <loc>https://webdevhub.link/frameworks-and-libraries</loc>
     <lastmod>2023-10-27</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://yourwebsiteurl.com/communities</loc>
+    <loc>https://webdevhub.link/communities</loc>
     <lastmod>2023-10-27</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://yourwebsiteurl.com/blogs</loc>
+    <loc>https://webdevhub.link/blogs</loc>
     <lastmod>2023-10-27</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>


### PR DESCRIPTION
This commit addresses several SEO improvements:

- Updated placeholder URLs in `public/robots.txt` and `public/sitemap.xml` to use your production domain `https://webdevhub.link/`.
- Updated the `openGraph.url` in `app/layout.tsx` to your production domain.
- Removed placeholder Open Graph image, Twitter image, and Twitter creator tags from `app/layout.tsx` as the assets/accounts do not currently exist. This prevents pointing to non-existent resources.

Individual pages currently inherit the global metadata from `app/layout.tsx`. Further improvements can be made by adding more specific titles and descriptions to these pages in a future update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated site metadata and public files to use the correct domain (https://webdevhub.link) instead of the placeholder URL.
  - Removed image and creator metadata from social sharing properties.
  - Updated sitemap and robots.txt to reference the actual site URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->