### PR TITLE
Remove breadcrumb navigation from all section pages

### DIFF
--- a/app/blogs/page.tsx
+++ b/app/blogs/page.tsx
@@ -1,14 +1,7 @@
 'use client';
 
 import React, { useEffect } from 'react';
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator,
-} from '@/components/ui/breadcrumb';
+
 import { SECTIONS } from '@/constants/sections';
 import ResourceCard from '@/components/ui/resource-card';
 import { useSearch } from '@/contexts/search-context';
@@ -40,17 +33,7 @@ export default function Page() {
   return (
     <div className="container mx-auto py-12 px-4 md:px-6 flex flex-col gap-10">
       <div className="space-y-2">
-        <Breadcrumb>
-          <BreadcrumbList>
-            <BreadcrumbItem>
-              <BreadcrumbLink href="/">Home</BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator />
-            <BreadcrumbItem>
-              <BreadcrumbPage>Blogs</BreadcrumbPage>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
+
 
         <h1 className="text-3xl font-bold tracking-tight">Blogs</h1>
         <p className="text-foreground-muted max-w-[700px]">

--- a/app/communities/page.tsx
+++ b/app/communities/page.tsx
@@ -1,14 +1,7 @@
 'use client';
 
 import React, { useEffect } from 'react';
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator,
-} from '@/components/ui/breadcrumb';
+
 import { SECTIONS } from '@/constants/sections';
 import ResourceCard from '@/components/ui/resource-card';
 import { useSearch } from '@/contexts/search-context';
@@ -41,17 +34,7 @@ export default function Page() {
   return (
     <div className="container mx-auto py-12 px-4 md:px-6 flex flex-col gap-10">
       <div className="space-y-2">
-        <Breadcrumb>
-          <BreadcrumbList>
-            <BreadcrumbItem>
-              <BreadcrumbLink href="/">Home</BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator />
-            <BreadcrumbItem>
-              <BreadcrumbPage>Communities</BreadcrumbPage>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
+
 
         <h1 className="text-3xl font-bold tracking-tight">
           Communities

--- a/app/developer-tools/page.tsx
+++ b/app/developer-tools/page.tsx
@@ -1,14 +1,7 @@
 'use client';
 
 import React, { useEffect } from 'react';
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator,
-} from '@/components/ui/breadcrumb';
+
 import { SECTIONS } from '@/constants/sections';
 import ResourceCard from '@/components/ui/resource-card';
 import { useSearch } from '@/contexts/search-context';
@@ -40,17 +33,7 @@ export default function Page() {
   return (
     <div className="container mx-auto py-12 px-4 md:px-6 flex flex-col gap-10">
       <div className="space-y-2">
-        <Breadcrumb>
-          <BreadcrumbList>
-            <BreadcrumbItem>
-              <BreadcrumbLink href="/">Home</BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator />
-            <BreadcrumbItem>
-              <BreadcrumbPage>Developer Tools</BreadcrumbPage>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
+
 
         <h1 className="text-3xl font-bold tracking-tight">
           Developer Tools

--- a/app/frameworks-and-libraries/page.tsx
+++ b/app/frameworks-and-libraries/page.tsx
@@ -1,14 +1,7 @@
 'use client';
 
 import React, { useEffect } from 'react';
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator,
-} from '@/components/ui/breadcrumb';
+
 import { SECTIONS } from '@/constants/sections';
 import ResourceCard from '@/components/ui/resource-card';
 import { useSearch } from '@/contexts/search-context';
@@ -41,17 +34,7 @@ export default function Page() {
   return (
     <div className="container mx-auto py-12 px-4 md:px-6 flex flex-col gap-10">
       <div className="space-y-2">
-        <Breadcrumb>
-          <BreadcrumbList>
-            <BreadcrumbItem>
-              <BreadcrumbLink href="/">Home</BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator />
-            <BreadcrumbItem>
-              <BreadcrumbPage>Frameworks & Libraries</BreadcrumbPage>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
+
 
         <h1 className="text-3xl font-bold tracking-tight">
           Frameworks & Libraries

--- a/app/learning-resources/page.tsx
+++ b/app/learning-resources/page.tsx
@@ -2,14 +2,7 @@
 
 import React, { useEffect } from 'react';
 import Link from 'next/link';
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator,
-} from '@/components/ui/breadcrumb';
+
 import { SECTIONS } from '@/constants/sections';
 import ResourceCard from '@/components/ui/resource-card';
 import { useSearch } from '@/contexts/search-context';
@@ -42,17 +35,7 @@ export default function Page() {
   return (
     <div className="container mx-auto py-12 px-4 md:px-6 flex flex-col gap-10">
       <div className="space-y-2">
-        <Breadcrumb>
-          <BreadcrumbList>
-            <BreadcrumbItem>
-              <BreadcrumbLink href="/">Home</BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator />
-            <BreadcrumbItem>
-              <BreadcrumbPage>Learning Resources</BreadcrumbPage>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
+
 
         <h1 className="text-3xl font-bold tracking-tight">
           Learning Resources


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed breadcrumb navigation from the Blogs, Communities, Developer Tools, Frameworks & Libraries, and Learning Resources pages. The main headings and content now appear without breadcrumb trails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->