### PR TITLE
Simplify hero banner by removing scroll animation and visibility state

### DIFF
--- a/components/ui/hero-banner.tsx
+++ b/components/ui/hero-banner.tsx
@@ -1,10 +1,3 @@
-import React, {
-  useEffect,
-  useRef,
-  useState,
-  useCallback,
-} from 'react';
-
 interface HeroBannerProps {
   title: string;
   description: string;
@@ -16,61 +9,8 @@ export function HeroBanner({
   description,
   tagline = 'Web Development Hub',
 }: HeroBannerProps) {
-  const [isVisible, setIsVisible] = useState(true);
-  const heroRef = useRef<HTMLDivElement>(null);
-  const thresholdRef = useRef<number>(0);
-  const ticking = useRef<boolean>(false);
-  const isVisibleRef = useRef<boolean>(true);
-
-  useEffect(() => {
-    const calculateThreshold = () => {
-      if (heroRef.current) {
-        thresholdRef.current = heroRef.current.offsetHeight / 3;
-      }
-    };
-
-    calculateThreshold();
-
-    window.addEventListener('resize', calculateThreshold);
-    return () =>
-      window.removeEventListener('resize', calculateThreshold);
-  }, []);
-
-  useEffect(() => {
-    isVisibleRef.current = isVisible;
-  }, [isVisible]);
-
-  const handleScroll = useCallback(() => {
-    if (!ticking.current) {
-      window.requestAnimationFrame(() => {
-        const scrollY = window.scrollY;
-        const threshold = thresholdRef.current;
-
-        if (scrollY > threshold && isVisibleRef.current) {
-          setIsVisible(false);
-        } else if (scrollY <= threshold && !isVisibleRef.current) {
-          setIsVisible(true);
-        }
-
-        ticking.current = false;
-      });
-
-      ticking.current = true;
-    }
-  }, []);
-
-  useEffect(() => {
-    window.addEventListener('scroll', handleScroll);
-    return () => window.removeEventListener('scroll', handleScroll);
-  }, [handleScroll]);
-
   return (
-    <div
-      ref={heroRef}
-      className={`min-h-[100vh] w-full sticky top-0 z-10 transition-transform duration-500 ease-in-out ${
-        !isVisible ? '-translate-y-full' : ''
-      }`}
-    >
+    <div className="min-h-[100vh] w-full">
       <section className="container mx-auto h-screen flex flex-col items-center justify-center text-center space-y-6 px-4">
         {tagline && (
           <div className="inline-block rounded-full bg-accent-neon/10 px-4 py-1.5 text-sm font-medium text-accent-neon mb-4">
@@ -83,7 +23,7 @@ export function HeroBanner({
         <p className="text-lg md:text-xl text-foreground-muted max-w-[700px] mt-4">
           {description}
         </p>
-        <div className="mt-8 animate-bounce">
+        <div className="mt-8">
           <svg
             xmlns="http://www.w3.org/2000/svg"
             width="24"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the hero banner to display as a static element without any scroll-based visibility toggling or animations. The banner no longer hides, shows, or animates based on scrolling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->