### PR TITLE
Update Desktop Navigation to refine conditional rendering logic

### DIFF
--- a/components/ui/navigation/desktop-navigation.tsx
+++ b/components/ui/navigation/desktop-navigation.tsx
@@ -136,15 +136,15 @@ export function DesktopNavigation({
           </div>
         </li>
 
-        {(isHomeActive && filteredNavItems.length > 0) ||
-          (isFavoritesActive && filteredNavItems.length > 0 && (
-            <li className="w-full">
-              <div
-                className="h-px w-6 bg-border/50 mx-auto"
-                aria-hidden="true"
-              ></div>
-            </li>
-          ))}
+        {((isHomeActive && filteredNavItems.length > 0) ||
+          (isFavoritesActive && filteredNavItems.length > 0)) && (
+          <li className="w-full">
+            <div
+              className="h-px w-6 bg-border/50 mx-auto"
+              aria-hidden="true"
+            ></div>
+          </li>
+        )}
 
         {(isHomeActive || isFavoritesActive) &&
           filteredNavItems.map((item, index) => (

--- a/components/ui/navigation/desktop-navigation.tsx
+++ b/components/ui/navigation/desktop-navigation.tsx
@@ -136,7 +136,8 @@ export function DesktopNavigation({
           </div>
         </li>
 
-        {(isHomeActive || isFavoritesActive) && (
+        {(isHomeActive ||
+          (isFavoritesActive && filteredNavItems.length > 0)) && (
           <li className="w-full">
             <div
               className="h-px w-6 bg-border/50 mx-auto"

--- a/components/ui/navigation/desktop-navigation.tsx
+++ b/components/ui/navigation/desktop-navigation.tsx
@@ -136,15 +136,15 @@ export function DesktopNavigation({
           </div>
         </li>
 
-        {(isHomeActive ||
-          (isFavoritesActive && filteredNavItems.length > 0)) && (
-          <li className="w-full">
-            <div
-              className="h-px w-6 bg-border/50 mx-auto"
-              aria-hidden="true"
-            ></div>
-          </li>
-        )}
+        {(isHomeActive && filteredNavItems.length > 0) ||
+          (isFavoritesActive && filteredNavItems.length > 0 && (
+            <li className="w-full">
+              <div
+                className="h-px w-6 bg-border/50 mx-auto"
+                aria-hidden="true"
+              ></div>
+            </li>
+          ))}
 
         {(isHomeActive || isFavoritesActive) &&
           filteredNavItems.map((item, index) => (


### PR DESCRIPTION
Update Desktop Navigation to refine conditional rendering logic for favorites, ensuring items are displayed only when there are filtered navigation items available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the display logic for the horizontal divider in the desktop navigation to ensure it only appears when relevant navigation items are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->