### PR TITLE
Reset search query when route changes using pathname dependency

### DIFF
--- a/contexts/search-context.tsx
+++ b/contexts/search-context.tsx
@@ -65,6 +65,11 @@ export function SearchProvider({
     setSearchResults([]);
   }, []);
 
+  // Reset search query when pathname (route) changes
+  useEffect(() => {
+    clearSearch();
+  }, [pathname, clearSearch]);
+
   useEffect(() => {
     // Handle search logic and default display logic in a single effect
     if (!searchQuery || searchQuery.trim() === '') {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search queries and results are now automatically cleared when navigating to a new page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->